### PR TITLE
[add] add GitHub Actions workflow for automated Docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,52 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+      - name: Login to GitHub Container Registry
+        continue-on-error: ${{ github.event_name != 'push' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          push: ${{ github.event_name == 'push' }}
+      - name: Push build cache
+        if: github.event_name == 'push'
+        uses: docker/build-push-action@v6
+        with:
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+          cache-to: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
           push: ${{ github.event_name == 'push' }}
+          build-args: |
+            UID=1001
+            GID=1001
       - name: Push build cache
         if: github.event_name == 'push'
         uses: docker/build-push-action@v6

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # openPNMTests
+
+[![Docker](https://github.com/lmmp-puc-rio/PNM-OOPStructure/actions/workflows/docker.yml/badge.svg)](https://github.com/lmmp-puc-rio/PNM-OOPStructure/actions/workflows/docker.yml)
+
 Initial tests with OpenPNM in for comparison with DuMuX


### PR DESCRIPTION
Add a `docker.yml` GitHub Actions workflow for building Docker images automatically and uploading them to the GitHub Packages repository for this repo.

The naming scheme for uploaded images is as follows:

- The most recent Git tag gets the default `latest` tag
- The master branch gets the `master` Docker tag
- Other Git tags are pushed with their own tags (e.g. `0.3.0` -> `0.3` & `0.3.0`)

Note that the workflow will run to test the image build for pull requests even in cases where it does not (currently) push the resulting images.

Finally, adds a badge to the README file to track build status.